### PR TITLE
Info with updates and some fixes

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -214,12 +214,16 @@ class Command(object):
                             help='reference name or path to conanfile file, '
                             'e.g., OpenSSL/1.0.2e@lasote/stable or ./my_project/')
         parser.add_argument("--file", "-f", help="specify conanfile filename")
-        self._parse_args(parser)
+        parser.add_argument("-r", "--remote", help='look for in the remote storage')
+        parser.add_argument("--options", "-o",
+                            help='load options to build the package, e.g., -o with_qt=true',
+                            nargs=1, action=Extender)
+        parser.add_argument("--settings", "-s",
+                            help='load settings to build the package, -s compiler:gcc',
+                            nargs=1, action=Extender)
 
         args = parser.parse_args(*args)
 
-        # Get False or a list of patterns to check
-        args.build = self._get_build_sources_parameter(args.build)
         option_dict = args.options or []
         settings_dict = args.settings or []
         current_path = os.getcwd()
@@ -233,7 +237,7 @@ class Command(object):
                               remote=args.remote,
                               options=option_dict,
                               settings=settings_dict,
-                              build_mode=args.build,
+                              build_mode=False,
                               info=True,
                               filename=args.file)
 

--- a/conans/client/deps_builder.py
+++ b/conans/client/deps_builder.py
@@ -222,6 +222,13 @@ class DepsBuilder(object):
         self._output = output
         self._loader = loader
 
+    def get_graph_updates_info(self, deps_graph):
+        """
+        returns a dict of conan_reference: 1 if there is an update, 0 if don't and -1 if local is newer
+        """
+        return {conan_reference: self._retriever.update_available(conan_reference)
+                for conan_reference, _ in deps_graph.nodes}
+
     def load(self, conan_ref, conanfile):
         """ compute the dependencies graph for:
         param conan_ref: ConanFileReference for installed conanfile or path to user one

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -145,7 +145,10 @@ class ConanManager(object):
             reference = None
 
         loader = self._loader(current_path, settings, options)
-        remote_proxy = ConanProxy(self._paths, self._user_io, self._remote_manager, remote, update)
+        # Not check for updates for info command, it'll be checked when dep graph is built
+        check_updates = not info
+        remote_proxy = ConanProxy(self._paths, self._user_io, self._remote_manager,
+                                  remote, update, check_updates)
 
         if reference_given:
             project_reference = None
@@ -175,7 +178,9 @@ class ConanManager(object):
         deps_graph = builder.load(reference, conanfile)
         registry = RemoteRegistry(self._paths.registry, self._user_io.out)
         if info:
-            Printer(self._user_io.out).print_info(deps_graph, project_reference, info, registry)
+            graph_updates_info = builder.get_graph_updates_info(deps_graph)
+            Printer(self._user_io.out).print_info(deps_graph, project_reference, 
+                                                  info, registry, graph_updates_info)
             return
         Printer(self._user_io.out).print_graph(deps_graph, registry)
 


### PR DESCRIPTION
- I'm not very happy with this... info was and keep being a little mess.
- Not happy with the enum -1, 0, 1 for package update status (but not sure about a constant)
- Removed --build from info command.
- Info command shows the update status.
- A test is failing by the new info ouput, but I'm sure its not the last iteration of this feature, so Its ok by now.
- Despite of the previous comments, its a little improvement.
