### PR TITLE
Unify load_class/module

### DIFF
--- a/conans/client/graph/printer.py
+++ b/conans/client/graph/printer.py
@@ -5,11 +5,11 @@ from collections import OrderedDict
 from conans.client.graph.graph import BINARY_SKIP
 
 
-def _get_python_requires(mod):
+def _get_python_requires(conanfile):
     result = set()
-    for py_require in getattr(mod, "python_requires", []):
+    for py_require in getattr(conanfile, "python_requires", []):
         result.add(py_require.conan_ref)
-        result.update(_get_python_requires(py_require.module))
+        result.update(_get_python_requires(py_require.conanfile))
     return result
 
 

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 
 from contextlib import contextmanager
-from conans.client.loader import parse_conanfile, parse_module
 from conans.client.recorder.action_recorder import ActionRecorder
 from conans.model.ref import ConanFileReference
 from conans.model.requires import Requirement

--- a/conans/test/integration/python_build_test.py
+++ b/conans/test/integration/python_build_test.py
@@ -831,3 +831,7 @@ class Project(base_class.PythonRequires2, base_class2.PythonRequires22):
         #   - packages
         self.assertIn("    project/1.0@jgsogo/test:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Build",
                       client.out)
+
+        #   - no mention to alias
+        self.assertNotIn("alias", client.out)
+        self.assertNotIn("alias2", client.out)


### PR DESCRIPTION
Consider this PR, I'm unifying the code used to load a `conanfile` and `module` in a single point. There is still a weird relationship between the classes `ConanFileLoader` and `ConanPythonRequire`. We need to address it, but not now.

**Important in this PR:**  now `python_requires` is stored always inside the `conanfile`. Previously it was stored in the module in the case of python requires. Now it is consistent.

**Question**: if we are storing it inside the `conanfile` object, it should be named `_conan_python_requires` according to naming conventions, no? Am I missing something?

Let's solve this one, before moving to https://github.com/jgsogo/conan/pull/7 