### PR TITLE
Add python_requires to pylint_plugin

### DIFF
--- a/conans/pylint_plugin.py
+++ b/conans/pylint_plugin.py
@@ -24,6 +24,8 @@ def transform_conanfile(node):
         "conans.client.file_copier").lookup("FileCopier")
     file_importer_class = MANAGER.ast_from_module_name(
         "conans.client.importer").lookup("_FileImporter")
+    python_requires_class = MANAGER.ast_from_module_name(
+        "conans.client.graph.python_requires").lookup("PyRequires")
 
     dynamic_fields = {
         "source_folder": str_class,
@@ -36,6 +38,7 @@ def transform_conanfile(node):
         "info": info_class,
         "copy": file_copier_class,
         "copy_deps": file_importer_class,
+        "python_requires": [str_class, python_requires_class],
     }
 
     for f, t in dynamic_fields.items():


### PR DESCRIPTION
Tested with this recipe file:

```python
from conans import ConanFile

class Pkg(ConanFile):

    name = "Pkg"
    python_requires = "Tool/[>=0.1]@user/channel"

    def configure(self):
        self.output.info("CONFIGURE VAR=%s" % self.python_requires["Tool"].module.var)

    def build(self):
        self.output.info("BUILD VAR=%s" % self.python_requires["Tool"].module.var)

```

