### PR TITLE
#6057 Fix test for version comparing

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -6,7 +6,7 @@ PyYAML>=3.11, <6.0
 patch-ng>=1.17.4, <1.18
 fasteners>=0.14.1
 six>=1.10.0,<=1.14.0
-node-semver>=0.6.1
+node-semver>=0.8.0
 distro>=1.0.2, <1.2.0
 future>=0.16.0, <0.19.0
 pygments>=2.0, <3.0

--- a/conans/test/unittests/client/tools/test_version.py
+++ b/conans/test/unittests/client/tools/test_version.py
@@ -107,5 +107,4 @@ class ToolVersionExtraComponentsTests(unittest.TestCase):
 
         # Unknown release field, not fail (loose=True) and don't affect compare
         self.assertTrue(Version.loose)
-        self.assertTrue(Version("1.2.3.4") == Version("1.2.3"))
-
+        self.assertTrue(Version("1.2.3.4") != Version("1.2.3"))


### PR DESCRIPTION
Since node-semver 0.8.0, versions with different number of digits are not considered equal. For instance, 1.1.1 == 1.1.1.1 until 0.7.0 was considered equal, however this rule changed in 0.8.0 and now is considered False.

We can't allow 0.6.1 and 0.7.0, because it will cause a different behavior for each version, resulting in new issues when calling tools.Version().