### PR TITLE
#6057 Compare micro versions

### DIFF
--- a/conans/client/tools/version.py
+++ b/conans/client/tools/version.py
@@ -32,7 +32,7 @@ class Version(object):
         return str(self._semver.patch)
 
     @property
-    def micro_versions(self):
+    def micro(self):
         return str(".".join(map(str, self._semver.micro_versions)))
 
     @property
@@ -54,6 +54,6 @@ class Version(object):
         return (self._semver.compare(other._semver) or self._compare_micro(other)) < 0
 
     def _compare_micro(self, other):
-        if self.micro_versions == other.micro_versions:
+        if self.micro == other.micro:
             return 0
-        return -1 if self.micro_versions < other.micro_versions else 1
+        return -1 if self.micro < other.micro else 1

--- a/conans/client/tools/version.py
+++ b/conans/client/tools/version.py
@@ -32,6 +32,10 @@ class Version(object):
         return str(self._semver.patch)
 
     @property
+    def micro_versions(self):
+        return str(".".join(map(str, self._semver.micro_versions)))
+
+    @property
     def prerelease(self):
         return str(".".join(map(str, self._semver.prerelease)))
 
@@ -42,9 +46,14 @@ class Version(object):
     def __eq__(self, other):
         if not isinstance(other, Version):
             other = Version(other)
-        return self._semver.compare(other._semver) == 0
+        return (self._semver.compare(other._semver) or self._compare_micro(other)) == 0
 
     def __lt__(self, other):
         if not isinstance(other, Version):
             other = Version(other)
-        return self._semver.compare(other._semver) < 0
+        return (self._semver.compare(other._semver) or self._compare_micro(other)) < 0
+
+    def _compare_micro(self, other):
+        if self.micro_versions == other.micro_versions:
+            return 0
+        return -1 if self.micro_versions < other.micro_versions else 1

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -6,7 +6,7 @@ PyYAML>=3.11, <6.0
 patch-ng>=1.17.4, <1.18
 fasteners>=0.14.1
 six>=1.10.0,<=1.14.0
-node-semver>=0.8.0
+node-semver>=0.6.1, <0.8.0
 distro>=1.0.2, <1.2.0
 future>=0.16.0, <0.19.0
 pygments>=2.0, <3.0

--- a/conans/test/unittests/client/tools/test_version.py
+++ b/conans/test/unittests/client/tools/test_version.py
@@ -47,11 +47,11 @@ class ToolVersionMainComponentsTests(unittest.TestCase):
         self.assertEqual(v.minor, "0")
         self.assertEqual(v.patch, "0")
 
-        v = Version("1.2.3.4")
+        v = Version("1.2.3.45.6")
         self.assertEqual(v.major, "1")
         self.assertEqual(v.minor, "2")
         self.assertEqual(v.patch, "3")
-        self.assertEqual(v.micro_versions, "4")
+        self.assertEqual(v.micro, "45.6")
 
     def test_convert_str(self):
         # Check that we are calling the string method

--- a/conans/test/unittests/client/tools/test_version.py
+++ b/conans/test/unittests/client/tools/test_version.py
@@ -47,6 +47,12 @@ class ToolVersionMainComponentsTests(unittest.TestCase):
         self.assertEqual(v.minor, "0")
         self.assertEqual(v.patch, "0")
 
+        v = Version("1.2.3.4")
+        self.assertEqual(v.major, "1")
+        self.assertEqual(v.minor, "2")
+        self.assertEqual(v.patch, "3")
+        self.assertEqual(v.micro_versions, "4")
+
     def test_convert_str(self):
         # Check that we are calling the string method
         class A(object):
@@ -108,3 +114,4 @@ class ToolVersionExtraComponentsTests(unittest.TestCase):
         # Unknown release field, not fail (loose=True) and don't affect compare
         self.assertTrue(Version.loose)
         self.assertTrue(Version("1.2.3.4") != Version("1.2.3"))
+        self.assertTrue(Version("1.2.3.4") > Version("1.2.3"))


### PR DESCRIPTION
Now we follow the same behavior as found in node-semver 0.8.0, micro versions are part of comparison.

TODO: Docs need to be updated, adding `micro_versions`

Related to PR https://github.com/conan-io/conan/pull/6941

