### PR TITLE
we need to pass 'CONAN_LINK_RUNTIME'

### DIFF
--- a/conans/client/toolchain/cmake.py
+++ b/conans/client/toolchain/cmake.py
@@ -116,7 +116,7 @@ class CMakeToolchain(object):
 
         # --  - CMake.flags --> CMakeDefinitionsBuilder::get_definitions
         {%- for it, value in definitions.items() %}
-        {%- if it.startswith('CONAN_') %}
+        {%- if it.startswith('CONAN_') and not it == 'CONAN_LINK_RUNTIME %}
         set({{ it }} "{{ value }}")
         {%- else %}
         set({{ it }} "{{ value }}" CACHE STRING "Value assigned from the Conan toolchain" FORCE)


### PR DESCRIPTION
**NOT TESTED**, but I don't want to forget about it.

VS runtime is adjusted in the file included via `CMAKE_PROJECT_INCLUDE`, so this value need to be available there. We can propagate it from the toolchain, or write down the value inside the file itself.
